### PR TITLE
データベース周りの環境設定ファイルの追加

### DIFF
--- a/database.yml
+++ b/database.yml
@@ -1,0 +1,19 @@
+default: &default
+  adapter: mysql2
+  encoding: utf8
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: 127.0.0.1
+  username: root
+  password: root
+
+development:
+  <<: *default
+  database: hello_world_rails_development
+
+test:
+  <<: *default
+  database: hello_world_rails_test
+
+production:
+  <<: *default
+  database: hello_world_rails_production

--- a/database.yml
+++ b/database.yml
@@ -8,13 +8,12 @@ default: &default
 
 development:
   <<: *default
-  database: hello_world_rails_development
+  database: qiita_clonerails_development
 
 test:
   <<: *default
-  database: hello_world_rails_test
+  database: qiita_clonerails_test
 
 production:
   <<: *default
-  database: hello_world_rails_production
-  
+  database: qiita_clonerails_production

--- a/database.yml
+++ b/database.yml
@@ -8,12 +8,12 @@ default: &default
 
 development:
   <<: *default
-  database: qiita_clone_rails_development
+  database: qiita_clone_development
 
 test:
   <<: *default
-  database: qiita_clone_rails_test
+  database: qiita_clone_test
 
 production:
   <<: *default
-  database: qiita_clone_rails_production
+  database: qiita_clone_production

--- a/database.yml
+++ b/database.yml
@@ -17,3 +17,4 @@ test:
 production:
   <<: *default
   database: hello_world_rails_production
+  

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.2'
+
+services:
+  database:
+    restart: always
+    image: mysql:latest
+    ports:
+      - 3306:3306
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql-datavolume:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+
+volumes:
+  mysql-datavolume:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,3 +15,4 @@ services:
 volumes:
   mysql-datavolume:
     driver: local
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,3 @@ services:
 volumes:
   mysql-datavolume:
     driver: local
-    


### PR DESCRIPTION
## 概要

下記のdocker関連ファイルを追加し、DB(mysql)と接続できるようにしました
- docker-compose.yml
- database.yml

これにより、docker-composeコマンド、mysqlコマンドが通るようになりました

```
$ docker-compose up -d
Creating network "qiita_clone_default" with the default driver
Creating qiita_clone_database_1 ... done
```

```
$ mysql -u root -p -h 127.0.0.1 
Enter password: 
.
.
.
mysql>
```

## 前回PRとの変更点
- PRの単位を、Task.5-1のみとしました
- ファイル作成単位でcommitを行いました
- PR内容が伝わりやすくなることを意識してPR文を作成しました
