### PR TITLE
application.rbの設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,7 @@ module QiitaClone
       g.template_engine false
       g.javascripts false
       g.stylesheets false
-      g.helper true
+      g.helper false
       g.test_framework :rspec,
                        view_specs: false,
                        routing_specs: false,

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,21 @@ module QiitaClone
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    config.generators do |g|
+      g.template_engine false
+      g.javascripts false
+      g.stylesheets false
+      g.helper true
+      g.test_framework :rspec,
+                       view_specs: false,
+                       routing_specs: false,
+                       helper_specs: false,
+                       controller_specs: false,
+                       request_specs: true
+    end
+
+    config.api_only = true
+
   end
 end


### PR DESCRIPTION
## 概要

config/application.rbを修正し、以下の設定を変更しました。

# rails generateコマンド時の自動生成ファイル
- view: 無し
- javascript: 無し
- stylesheet: 無し
- helper: 有り
- テストフレームワーク: rspec request_specsのみ自動生成

# Web API運用
config.api_only = trueとし、RailsをWeb APIとして運用する設定を加えました。
