### PR TITLE
Createアクションの追加

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -22,6 +22,6 @@ class Api::V1::ArticlesController < Api::V1::ApiController
 
     # 後でdevise_auth_tokenに取って替わる
     def current_user
-      @curren_user = User.first
+      @current_user ||= User.first
     end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -8,4 +8,20 @@ class Api::V1::ArticlesController < Api::V1::ApiController
     article = Article.find(params[:id])
     render json: article
   end
+
+  def create
+    article = current_user.articles.create!(article_params)
+    render json: article
+  end
+
+  private
+
+    def article_params
+      params.require(:article).permit(:title,:content)
+    end
+
+    # 後でdevise_auth_tokenに取って替わる
+    def current_user
+      @curren_user = User.first
+    end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   private
 
     def article_params
-      params.require(:article).permit(:title,:content)
+      params.require(:article).permit(:title, :content)
     end
 
     # 後でdevise_auth_tokenに取って替わる

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -1,5 +1,8 @@
 require: "rubocop-rspec"
 
+RSpec/AnyInstance:
+  Enabled: false
+
 # 日本語だと「〜の場合」になるので suffix でないと対応できない
 RSpec/ContextWording:
   Enabled: false

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Articles", type: :request do
 
     context "正しく article を作成する場合" do
       it "article のレコードが作成できる" do
-        expect { subject }.to change { Article.count }.by(1)
+        expect { subject }.to change { current_user.articles.count }.by(1)
         res = JSON.parse(response.body)
         expect(res["title"]).to eq params[:article][:title]
         expect(res["content"]).to eq params[:article][:content]

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -47,4 +47,24 @@ RSpec.describe "Articles", type: :request do
       end
     end
   end
+
+  describe "POST api/v1/articles" do
+    subject { post(api_v1_articles_path, params:params) }
+    let(:current_user) { create(:user) }
+    let(:params) { {article: attributes_for(:article)} }
+
+    before do
+      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
+    end
+
+    context "正しく article を作成する場合" do
+      it "article のレコードが作成できる" do
+        expect { subject }.to change { Article.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["content"]).to eq params[:article][:content]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Articles", type: :request do
     end
 
     context "指定した id の article が存在しない場合" do
-      let(:article_id) { 1000000 }
+      let(:article_id) { 1_000_000 }
 
       it "article が見つからない" do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
@@ -49,9 +49,10 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "POST api/v1/articles" do
-    subject { post(api_v1_articles_path, params:params) }
+    subject { post(api_v1_articles_path, params: params) }
+
     let(:current_user) { create(:user) }
-    let(:params) { {article: attributes_for(:article)} }
+    let(:params) { { article: attributes_for(:article) } }
 
     before do
       allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)


### PR DESCRIPTION
## 概要
- articles_controller にcreateアクションを追加しました。
- createアクションに対するテストを書きました。

## コントローラーについて
-  devise_token_authで実装することを見越して、current_userメソッドのモックを作りました（これは常にUser.firstを返します）

## テストについて
-  allow_any_instance_ofメソッドを用いて、curret_userメソッドを回避するようにしました（代わりにFactoryBotで生成したuserでarticle.create!を行います）
- allow_any_instance_ofメソッドを使えるよう、rubocopの設定を修正しました。
