### PR TITLE
destroyアクションの定義

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -20,6 +20,12 @@ class Api::V1::ArticlesController < Api::V1::ApiController
     render json: article
   end
 
+  def destroy
+    article = current_user.articles.find(params[:id])
+    article.destroy
+    render json: {}, status: :ok
+  end
+
   private
 
     def article_params

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
-  before_action :set_article, only:[:update, :destroy]
+  before_action :set_article, only: [:update, :destroy]
 
   def index
     articles = Article.order(created_at: :desc)

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
+  before_action :set_article, only:[:update, :destroy]
+
   def index
     articles = Article.order(created_at: :desc)
     render json: articles
@@ -15,14 +17,12 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   end
 
   def update
-    article = current_user.articles.find(params[:id])
-    article.update!(article_params)
-    render json: article
+    @article.update!(article_params)
+    render json: @article
   end
 
   def destroy
-    article = current_user.articles.find(params[:id])
-    article.destroy!
+    @article.destroy!
     render json: {}, status: :ok
   end
 
@@ -30,6 +30,10 @@ class Api::V1::ArticlesController < Api::V1::ApiController
 
     def article_params
       params.require(:article).permit(:title, :content)
+    end
+
+    def set_article
+      @article = current_user.articles.find(params[:id])
     end
 
     # 後でdevise_auth_tokenに取って替わる

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
 
   def destroy
     article = current_user.articles.find(params[:id])
-    article.destroy
+    article.destroy!
     render json: {}, status: :ok
   end
 

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -50,6 +50,10 @@ RSpec/InstanceVariable:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/LetSetup:
+  Enabled: false
+
+
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。
 RSpec/NamedSubject:

--- a/config/rubocop/rubocop.yml
+++ b/config/rubocop/rubocop.yml
@@ -142,6 +142,7 @@ Metrics/BlockLength:
     - "config/routes.rb"
     - "config/routes/**/*.rb"
     - "*.gemspec"
+    - "db/seeds.rb"
 
 # 6 は強すぎるので緩める
 Metrics/CyclomaticComplexity:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,7 +44,7 @@ ActiveRecord::Base.transaction do
 
       ArticleLike.create!(
         user_id: other_user_id,
-        article: article
+        article: article,
       )
     end
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -98,4 +98,30 @@ RSpec.describe "Articles", type: :request do
       end
     end
   end
+
+  describe "DELETE /aoi/v1/articles/:id" do
+    subject { delete(api_v1_article_path(article.id)) }
+    let(:current_user) { create(:user) }
+
+    before do
+      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
+    end
+
+    context "article の作者が自分自身の場合" do
+      let!(:article) { create(:article, user: current_user) }
+
+      it "削除できる" do
+        expect { subject }.to change { Article.count }.by(-1)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "article の作者が他人の場合" do
+      let!(:article) { create(:article) }
+
+      it "削除できない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Articles", type: :request do
       let!(:article) { create(:article, user: current_user) }
 
       it "削除できる" do
-        expect { subject }.to change { Article.count }.by(-1)
+        expect { subject }.to change { current_user.articles.count }.by(-1)
         expect(response).to have_http_status(:ok)
       end
     end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -101,6 +101,7 @@ RSpec.describe "Articles", type: :request do
 
   describe "DELETE /aoi/v1/articles/:id" do
     subject { delete(api_v1_article_path(article.id)) }
+
     let(:current_user) { create(:user) }
 
     before do


### PR DESCRIPTION
## 概要
- articles_controller に destroy アクションを追加しました。
- destroy アクションに対応する正常系・異常系テストを追加しました。
- rubocop の設定を一部変更しました。
  - Metrics/BlockLength から db/seeds.rb を除外
  - rspec 内で let!() を使用したいため、RSpec/LetSetup を false に変更