### PR TITLE
devise_token_authのヘルパーメソッドの利用

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,3 +1,6 @@
 class Api::V1::ApiController < ApplicationController
   include DeviseTokenAuth::Concerns::SetUserByToken
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :set_article, only: [:update, :destroy]
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
     articles = Article.order(created_at: :desc)
@@ -34,10 +35,5 @@ class Api::V1::ArticlesController < Api::V1::ApiController
 
     def set_article
       @article = current_user.articles.find(params[:id])
-    end
-
-    # 後でdevise_auth_tokenに取って替わる
-    def current_user
-      @current_user ||= User.first
     end
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -49,14 +49,11 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "POST api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, headers: headers ) }
 
+    let(:headers) { current_user.create_new_auth_token }
     let(:current_user) { create(:user) }
     let(:params) { { article: attributes_for(:article) } }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
 
     context "正しく article を作成する場合" do
       it "article のレコードが作成できる" do
@@ -70,14 +67,11 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "PATCH api/v1/articles" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
+    let(:headers) { current_user.create_new_auth_token }
     let(:current_user) { create(:user) }
     let(:params) { { article: { title: Faker::Lorem.sentence, content: Faker::Lorem.paragraph, created_at: Time.current } } }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
 
     context "article の作者が自分自身の場合" do
       let(:article) { create(:article, user: current_user) }
@@ -100,8 +94,9 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "DELETE /aoi/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
+    let(:headers) { current_user.create_new_auth_token }
     let(:current_user) { create(:user) }
 
     before do

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Articles", type: :request do
   end
 
   describe "POST api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params, headers: headers ) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     let(:headers) { current_user.create_new_auth_token }
     let(:current_user) { create(:user) }


### PR DESCRIPTION
## 概要
- devise_token_authが提供するメソッド（current_user, authenticate_user!, user_signed_in?）を実装しました
- articles_controllerのcreate, updatem destroyアクションについて、認証済みユーザーのみが実行できるようにしました
- 上記3アクションのテストにおいて、ヘッダー情報をURL渡してログイン状態を再現できるようにしました。