### PR TITLE
Current articlesコントローラーの作成

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Current::ArticlesController < Api::V1::ApiController
+  before_action :authenticate_user!, only: [:index]
+
+  def index
+    articles = current_user.articles.published.order(created_at: :desc)
+    render json: articles
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      namespace "current" do
+        resources :articles, only: [:index]
+      end
       namespace "articles" do
         resources :drafts, only: [:index, :show]
       end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    let(:headers) { current_user.create_new_auth_token }
+    let(:current_user) { create(:user) }
+
+    context "カレントユーザーが公開状態の articles を保存している場合" do
+      before do
+        create_list(:article, 3, user: current_user)
+        create_list(:article, 2, :save_draft, user: current_user)
+      end
+
+      it "公開状態の article の一覧が取得できる" do
+        subject
+        expect(Article.count).to eq 5
+        res = JSON.parse(response.body)
+        expect(res.length).to eq 3
+        expect(res[0].keys).to eq ["id", "title", "content", "created_at", "updated_at", "likes_count", "user"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
ユーザーが、自分自身の公開記事一覧を見られるマイページ機能を追加しました。

- ``/api/v1/current/articles_contoller.rb`` を作成
- endpoint を ``/api/v1/current/articles``に設定
- テストを記述