### PR TITLE
feat: Execute 'yarn add @babel/preset-env --dev'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "qiita_clone",
   "private": true,
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^5.9.0",
     "@rails/webpacker": "^4.0.7",
     "axios": "^0.19.0",
     "highlight.js": "^9.15.8",
@@ -15,10 +16,10 @@
     "vue-router": "^3.0.6",
     "vue-template-compiler": "^2.6.10",
     "vue2-timeago": "^1.2.2",
-    "vuetify": "^1.5.16",
-    "@fortawesome/fontawesome-free": "^5.9.0"
+    "vuetify": "^1.5.16"
   },
   "devDependencies": {
+    "@babel/preset-env": "^7.10.4",
     "webpack-dev-server": "^3.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -741,7 +741,7 @@
     levenary "^1.1.1"
     semver "^5.5.0"
 
-"@babel/preset-env@^7.7.1":
+"@babel/preset-env@^7.10.4", "@babel/preset-env@^7.7.1":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.10.4.tgz#fbf57f9a803afd97f4f32e4f798bb62e4b2bef5f"
   integrity sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==


### PR DESCRIPTION
## 概要
- herokuのデプロイする際に、以下のエラーが発生したので修正。

### エラー内容
```bash
remote:        ERROR in ./app/javascript/packs/application.js
remote:        Module build failed (from ./node_modules/babel-loader/lib/index.js):
remote:        Error: [BABEL] /tmp/build_a8ecc959860d2173dc185ac43183e3fd/app/javascript/packs/application.js: Could not find plugin "proposal-numeric-separator". Ensure there is an entry in ./available-plugins.js for it. (While processing: "/tmp/build_a8ecc959860d2173dc185ac43183e3fd/node_modules/@babel/preset-env/lib/index.js")
```

## 修正手順
- 「Could not find plugin "proposal-numeric-separator".」 でググる
- https://qiita.com/se_fy/items/c6e8780edc40c2caa197の記事を見つける
- 上記記事の下記リンク先にジャンプ
  - https://babeljs.io/docs/en/babel-preset-env
- `yarn add @babel/preset-env --dev` を実行
- 上記実行した際の差分をリモートリポジトリにpush
- herokuにデプロイ
- デプロイ成功 

## 修正項目
- package.json
- yarn.lock